### PR TITLE
Fix a mistake regarding default timeout val

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # StrongLoop Smart Profiling example
 
-This application demonstrates Smart Profiling in StrongLoop Arc. 
-The application includes a client and a server; the client sends requests to itself with a 
+This application demonstrates Smart Profiling in StrongLoop Arc.
+The application includes a client and a server; the client sends requests to itself with a
 user-defined timeout value.
-The server application processes requests until the specified timeout is exceeded. 
-It then returns the number of successfully completed operations to the client, which displays a 
+The server application processes requests until the specified timeout is exceeded.
+It then returns the number of successfully completed operations to the client, which displays a
 graph of the values.
 
 ## Requirements
@@ -34,7 +34,7 @@ that StrongLoop has provisioned a license for you, follow the procedure below.
 
 **NOTE**: If you're going to run both Arc and StrongLoop PM on one Linux system, skip this step.
 
-If the Linux system where you'll run PM is different than the system where you'll run Arc (a typical setup), 
+If the Linux system where you'll run PM is different than the system where you'll run Arc (a typical setup),
 then install StrongLoop PM on the Linux system:
 
 ```
@@ -54,7 +54,7 @@ $ sl-pm
 
 This will start PM, listening by default on port 8701.
 
-## Use Arc to build, deploy, and profile 
+## Use Arc to build, deploy, and profile
 
 ### Get the application
 
@@ -85,11 +85,11 @@ StrongLoop Arc will open in your default web browser.
 1. Under **Deploy tar file**:
   * **Fully qualified path to archive**: Enter the full path to the tar file; for example, `/Users/fred/smartprofiling-example-app-1.0.0.tgz`.  
   * **Hostname**: Domain name or IP address and port number (default 8701) of the server running PM.
-  * **Processes**: Leave the default, 1. 
+  * **Processes**: Leave the default, 1.
   * Click **Deploy**.
   * After a while, you'll see the message `Successfully deployed using tar file`.
 1. Confirm that the application is running: In a web browser, load the application,by default at: `http://<pm host>:3001/`.  You should see the app page.
-  
+
 > NOTE: For this demo, make sure you run the application with one worker process to avoid any confusion.
 
 ### Configure license
@@ -119,15 +119,15 @@ Following this procedure will push the license from Arc to the system running St
 
 ### Use the application
 
-Navigate to the Demo application, by default at `http://<pm-host>:3001`. 
+Navigate to the Demo application, by default at `http://<pm-host>:3001`.
 
-For **Timeout**, ensure the default value of "100" is present, then click **Start**.
+For **Timeout**, ensure the default value of "50" is present, then click **Start**.
 
 The application will start sending requests, which will process for the time
 specified. The amount of work done before the timeout specified will be shown
 on the graph.
 
-### Start Smart Profiling 
+### Start Smart Profiling
 
 In Arc:
 
@@ -137,13 +137,13 @@ In Arc:
 4. Click the grey box containing the process ID; it will turn blue.
 5. Click **Profile settings (full)**.  You'll see the Profiler Settings dialog.
 6. In the Profiler Settings dialog, click **Smart**.  
- * If you do not see the Smart Profile settings option, ensure you are running PM on Linux, 
+ * If you do not see the Smart Profile settings option, ensure you are running PM on Linux,
    have the correct version of PM, the necessary license, and have pushed the license to PM.
-7. Enter the following values: `Event Loop Execution Threshold` - 50 and `Max Samples` - keep the default, 10.
+7. Enter the following values: `Event Loop Execution Threshold` - 100 and `Max Samples` - keep the default, 10.
 8. Click **OK**.
 
 > In the demo application you'll see that the graph does not significantly
-> change. This is because of the decreased overhead of using Smart Profiling 
+> change. This is because of the decreased overhead of using Smart Profiling
 > versus standard (full) profiling.
 
 After a few minutes, increase the timeout in the demo app to 100. This will
@@ -153,18 +153,18 @@ Cycles" would have been exceeded.
 
 To view CPU profiles, click on them in the list on the left side of the page.
 
-There are two Smart Profiling settings: 
+There are two Smart Profiling settings:
 * **Timeout** - Minimum time the process which is being profiled needs to
 spend processing a request before it begins recording profiling data for that
 request. Increasing this value reduces the overhead of running profiling,
 by limiting the amount of time the profiling is running on the processes.
 * **Max Cycles** - The profile data for a process will not be available until after profiling has
-been turned off for that processes.  You can either turn offf profiling manually 
-(by selecting the PID, and clicking the 'stop' button) or 
+been turned off for that processes.  You can either turn off profiling manually
+(by selecting the PID, and clicking the 'stop' button) or
 automatically, after the profiler has triggered (by exceeding the
 profiler timeout) a specified number of times.
 
-In general, the values for these settings depend on the application you're profililng.  For this demo, use:
+In general, the values for these settings depend on the application you're profiling.  For this demo, use:
 
 - Threshold: 100 ms
 - Max Cycles: 10


### PR DESCRIPTION
Fix an mistake in the demo instructions which incorrectly states the
starting conditions for the threshold value should be 100 instead of
the correct value of 50.
